### PR TITLE
fix: refresh data only after take actions

### DIFF
--- a/src/AAVE.jsx
+++ b/src/AAVE.jsx
@@ -435,8 +435,12 @@ function formatHealthFactor(healthFactor) {
   return Big(healthFactor).toFixed(2, ROUND_DOWN);
 }
 
-// update data in async manner
-function updateData() {
+/**
+ * Update AAVE data
+ *
+ * @param {boolean} refresh  needs to refresh data if not updated yet
+ */
+function updateData(refresh) {
   const provider = Ethers.provider();
   if (!provider) {
     return;
@@ -518,15 +522,15 @@ function updateData() {
       });
 
       // get user borrow data
-      updateUserDebts(marketsMapping, assetsToSupply);
+      updateUserDebts(marketsMapping, assetsToSupply, refresh);
     });
 
     // get user supplies
-    updateUserSupplies(marketsMapping);
+    updateUserSupplies(marketsMapping, refresh);
   });
 }
 
-function updateUserSupplies(marketsMapping) {
+function updateUserSupplies(marketsMapping, refresh) {
   const prevYourSupplies = state.yourSupplies;
   getUserDeposits(state.chainId, state.address).then((userDepositsResponse) => {
     if (!userDepositsResponse) {
@@ -553,14 +557,18 @@ function updateUserSupplies(marketsMapping) {
       yourSupplies,
     });
 
-    if (JSON.stringify(prevYourSupplies) === JSON.stringify(yourSupplies)) {
+    if (
+      refresh &&
+      JSON.stringify(prevYourSupplies) === JSON.stringify(yourSupplies) &&
+      yourSupplies.length !== 0
+    ) {
       console.log("refresh supplies again ...", prevYourSupplies, yourSupplies);
       setTimeout(updateData, 500);
     }
   });
 }
 
-function updateUserDebts(marketsMapping, assetsToSupply) {
+function updateUserDebts(marketsMapping, assetsToSupply, refresh) {
   if (!marketsMapping || !assetsToSupply) {
     return;
   }
@@ -639,7 +647,10 @@ function updateUserDebts(marketsMapping, assetsToSupply) {
       assetsToBorrow,
     });
 
-    if (JSON.stringify(prevYourBorrows) === JSON.stringify(yourBorrows)) {
+    if (
+      refresh &&
+      JSON.stringify(prevYourBorrows) === JSON.stringify(yourBorrows)
+    ) {
       console.log("refresh borrows again ...", prevYourBorrows, yourBorrows);
       setTimeout(updateData, 500);
     }
@@ -648,7 +659,7 @@ function updateUserDebts(marketsMapping, assetsToSupply) {
 
 function onActionSuccess({ msg, callback }) {
   // update data if action finishes
-  updateData();
+  updateData(true);
   // update UI after data has almost loaded
   setTimeout(() => {
     if (callback) {


### PR DESCRIPTION
Fix the infinite data refresh issue when user has no supplies or borrows. 